### PR TITLE
Improvements

### DIFF
--- a/src/amqp/broker.ts
+++ b/src/amqp/broker.ts
@@ -119,7 +119,11 @@ export class AmqpBroker implements MessageBroker {
         const options = AmqpBroker.getPublishOptions(message);
 
         return this.channels.use(async (channel) => {
-            await AmqpBroker.assert({ channel, exchange, routingKey });
+            if (message.properties.assertQueue) {
+                await AmqpBroker.assert({ channel, exchange, routingKey });
+            } else {
+                await channel.checkQueue(routingKey)
+            }
 
             return AmqpBroker.doPublish({
                 body,

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -115,6 +115,8 @@ export interface TaskProperties {
     priority: number;
     /** Used by redis to select queue. Typically `"celery"` */
     queue: string;
+    /** Flag whether to call assertQueue (true) or checkQueue (false). Default is true. */
+    assertQueue: boolean;
     /** Queue name to send replies to. Used for RPC result backend. */
     reply_to?: string;
 }

--- a/src/task.ts
+++ b/src/task.ts
@@ -319,31 +319,25 @@ export class Task<T> {
      * If `compression` is `"identity"`, there will not be a corresponding
      * field in the headers returned.
      *
-     * @param args The positional arguments to pack into the headers.
      * @param compression The compression type to indicate.
      * @param eta The earliest time this task should be executed as an ISO 8601
      *            date string.
      * @param expires The latest time this task should be executed as an ISO
      *                8601 date string.
-     * @param kwargs The keyword arguments to pack into the headers.
      * @param id The UUID of this task.
      * @returns The headers of a task message to be queued.
      */
-    private createHeaders({ args, compression, eta, expires, kwargs, id }: {
-        args: Args;
+    private createHeaders({ compression, eta, expires, id }: {
         compression: Packer.Compressor;
         eta: string | null;
         expires: string | null;
         id: string;
-        kwargs: KeywordArgs;
     }): TaskHeaders {
         const base: TaskHeaders = {
-            argsrepr: JSON.stringify(args),
             eta,
             expires,
             group: null,
             id,
-            kwargsrepr: JSON.stringify(kwargs),
             lang: "py",
             origin: Task.getOrigin(),
             parent_id: null,


### PR DESCRIPTION
Hey, I'd like to add two improvements to `celery-ts`:

1. Don't send the task args/kwargs in the message header: it is unnecessary and large payloads could cause issues with AMQP protocol
2. Add ability to disable calling `assertQueue` because it won't work with manually created queues with different config. Rather, `checkQueue` is called to check the existence of the queue

These two are important fixes that I need in my software.
Thanks for reviewing!