### PR TITLE
chore(build): Disable integration test in GHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,5 +30,5 @@ jobs:
     - name: Run unit test
       run: npm run test
 
-    - name: Run integration test
-      run: npm run test-integration
+#    - name: Run integration test
+#      run: npm run test-integration


### PR DESCRIPTION
This doesn't work because `localhost` doesn't work. Needs work. Works locally. Disable for now.